### PR TITLE
Infinite scroll is made async and debounced

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+src/**/*.d.ts
+types/**/*.d.ts

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,6 +2,7 @@ module.exports = {
     root: true,
     env: {
         browser: true,
+        commonjs: true,
         node: true,
         es6: true
     },

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In your template you can add:
 The `VirtualGrid` takes multiple custom function as properties
 
 -   **updateFunction**:
-    An async function that will populate the grid, constructor is the following `updateFunction(params: { offset: number }, cb: (error: Error, results?: VirtualGrid.Item[]) => void) => void`.
+    An async function that will populate the grid, constructor is the following `updateFunction<P>(params: { offset: number }) => Promise<VirtualGrid.Item<P>[]>`. For synchronous function just return immediately your content with `Promise.resolve([you_content])` for instance.
     The offset will be incremented (+1) each time the function is called.
 -   **getGridGap**:
     A function that will define the gap between elements of the grid, constructor is the following `getGridGap(elementWidth: number, windowHeight: number) => number`.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ In your template you can add:
 The `VirtualGrid` takes multiple custom function as properties
 
 -   **updateFunction**:
-    A function that will populate the grid, constructor is the following `updateFunction(params: { offset: number }) => VirtualGrid.Item[]`.
+    An async function that will populate the grid, constructor is the following `updateFunction(params: { offset: number }, cb: (error: Error, results?: VirtualGrid.Item[]) => void) => void`.
     The offset will be incremented (+1) each time the function is called.
 -   **getGridGap**:
     A function that will define the gap between elements of the grid, constructor is the following `getGridGap(elementWidth: number, windowHeight: number) => number`.
@@ -53,7 +53,7 @@ The `VirtualGrid` takes multiple custom function as properties
     A function that set the width of columns in the grid, constructor is the following `getColumnCount(elementWidth: number) => number;`.
 -   **getWindowMargin**:
     A function that set the margin size used for windowing (virtualization), constructor is the following `getWindowMargin(windowHeight: number) => number;`.
--   **getWindowMargin**:
+-   **getItemRatioHeight**:
     A function that provides a way to compute ratio height/width depending on the display (by default it preserves ratio), constructor is the following `getItemRatioHeight(height: number, width: number, columnWidth: number) => number;`.
 
 Properties are provided with default functions that you can use or get inspired from in `src/utils.ts`.

--- a/example/App.vue
+++ b/example/App.vue
@@ -29,10 +29,10 @@ export default class App extends Vue {
         return Math.floor(Math.random() * high) + low;
     }
 
-    pullData(params: { offset: number }): Item<CustomDataTypes>[] {
+    pullData(params: { offset: number }): Promise<Item<CustomDataTypes>[]> {
         // This is to try when we reach end of infinite scroll (only 5 loads)
         if (params.offset > 5) {
-            return [];
+            return Promise.resolve([]);
         }
 
         // Add a title at each section
@@ -82,7 +82,7 @@ export default class App extends Vue {
             };
         });
 
-        return [sectionTitle, ...randomImages, ...sectionMap];
+        return Promise.resolve([sectionTitle, ...randomImages, ...sectionMap]);
     }
 }
 </script>


### PR DESCRIPTION
It is likely that loading more content is an async call, so I made it a default.

In case someone wants to do it with a sync function, they should return immediately in their code with `Promise.resolve([content])` (depending on their implementation).

Also i used computed data instead of refreshing all values everytime.